### PR TITLE
Added `UnpackingMapper`

### DIFF
--- a/smashed/interfaces/huggingface.py
+++ b/smashed/interfaces/huggingface.py
@@ -123,6 +123,10 @@ class BinarizerMapper(_HuggingFaceInterfaceMixInMapper, shape.BinarizerMapper):
     __sequence_type__: type = features.Sequence
 
 
+class UnpackingMapper(_HuggingFaceInterfaceMixInMapper, shape.UnpackingMapper):
+    ...
+
+
 class TokenizerMapper(
     _HuggingFaceInterfaceMixInMapper, tokenize.TokenizerMapper
 ):

--- a/smashed/interfaces/simple.py
+++ b/smashed/interfaces/simple.py
@@ -174,6 +174,10 @@ class BinarizerMapper(_SimpleInterfaceMixInMapper, shape.BinarizerMapper):
     ...
 
 
+class UnpackingMapper(_SimpleInterfaceMixInMapper, shape.UnpackingMapper):
+    ...
+
+
 class TokenizerMapper(_SimpleInterfaceMixInMapper, tokenize.TokenizerMapper):
     ...
 

--- a/smashed/mappers/shape.py
+++ b/smashed/mappers/shape.py
@@ -1,7 +1,7 @@
 from itertools import chain
-from typing import Dict
+from typing import Any, Dict, Iterable, List, Optional
 
-from ..base.mapper import SingleBaseMapper
+from ..base.mapper import BatchedBaseMapper, SingleBaseMapper
 from ..base.types import Features, FeatureType, TransformElementType
 
 
@@ -49,3 +49,124 @@ class BinarizerMapper(SingleBaseMapper):
             }
         else:
             return {field_name: 1 if data[field_name] > self.threshold else 0}
+
+
+class UnpackingMapper(BatchedBaseMapper):
+    _DRP_EXTRA = "drop"
+    _RPT_EXTRA = "repeat"
+
+    def __init__(
+        self,
+        fields_to_unpack: Optional[List[str]] = None,
+        fields_to_ignore: Optional[List[str]] = None,
+        ignored_behavior: Optional[str] = None,
+    ) -> None:
+        """Unpacks some or all fields in a dataset sample.
+        Useful when features contain a list of values, but you want to
+        want individual values for each sample.
+
+        Args:
+            fields_to_unpack (Optional[List[str]], optional): List of fields to
+                unpack. When not None, the other fields will be repeated (if
+                `ignore_behavior` is not set to "repeat") or dropped (if
+                `ignore_behavior` is set to "drop"). Only one between
+                `fields_to_unpack` and `fields_to_ignore` can be set. Defaults
+                to None.
+            fields_to_ignore (Optional[List[str]], optional): List of fields to
+                ignore. When not None, the fields provided will be dropped/
+                duplicated, while the others will be unpacked. Only one between
+                `fields_to_unpack` and `fields_to_ignore` can be set. Defaults
+                to None.
+            ignore_behavior (Optional[str], optional): How to handle fields that
+                are not unpacked. Can be "drop" or "repeat". Defaults to None.
+                Must be set when either `fields_to_unpack` or `fields_to_ignore`
+                is not None.
+        """
+
+        if fields_to_unpack is not None and fields_to_ignore is not None:
+            raise ValueError(
+                "Must specify only one of `fields_to_unpack` "
+                "or `fields_to_ignore`"
+            )
+
+        if (
+            fields_to_unpack is not None or fields_to_ignore is not None
+        ) and ignored_behavior not in {self._DRP_EXTRA, self._RPT_EXTRA}:
+            raise ValueError(
+                f"When specifying `fields_to_unpack` or `fields_to_ignore`, "
+                f"`ignore_behavior` must be one of {self._DRP_EXTRA} or "
+                f"{self._RPT_EXTRA} but got {ignored_behavior} instead!"
+            )
+
+        if fields_to_unpack is not None:
+            field_names = set(fields_to_unpack)
+            self.check_unpack_fn = lambda f: f in field_names
+        elif fields_to_ignore is not None:
+            field_names = set(fields_to_ignore)
+            self.check_unpack_fn = lambda f: f not in field_names
+        else:
+            field_names = None
+            # unpack all!
+            self.check_unpack_fn = lambda _: True
+
+        self.ignore_behavior = ignored_behavior
+
+        super().__init__(
+            input_fields=list(field_names) if field_names else None,
+            output_fields=list(field_names) if field_names else None,
+        )
+
+    def transform(
+        self, data: Iterable[TransformElementType]
+    ) -> Iterable[TransformElementType]:
+
+        # we get the names of fields to unpack after seeing the
+        # first sample; so we set this to None for now
+        all_field_names_to_unpack: Optional[List[str]] = None
+
+        # iterate over all samples
+        for packed_sample in data:
+
+            # first, compute the names of fields to unpack
+            if all_field_names_to_unpack is None:
+                all_field_names_to_unpack = [
+                    k for k in packed_sample.keys() if self.check_unpack_fn(k)
+                ]
+                if len(all_field_names_to_unpack) == 0:
+                    # raise an error if there's nothing to unpack,
+                    # which might indicate an error in setting up the mapper
+                    raise ValueError("No fields to unpack!")
+
+            unpacked_samples_it: Iterable[Dict[str, Any]] = (
+                # this re-attached all the field names to just the values
+                # of the new unpacked samples.
+                {
+                    k: v
+                    for k, v in zip(
+                        all_field_names_to_unpack, unpacked_element_values
+                    )
+                }
+                # this zip goes from list of features, each containing
+                # multiple elements in this packed sample, to a list of
+                # list of features in a element.
+                for unpacked_element_values in zip(
+                    *(packed_sample[k] for k in all_field_names_to_unpack)
+                )
+            )
+
+            if self.ignore_behavior == self._RPT_EXTRA:
+                # duplicate the fields that have not been unpacked
+                # in all new samples
+
+                features_to_duplicate = {
+                    k: v
+                    for k, v in packed_sample.items()
+                    if k not in all_field_names_to_unpack
+                }
+                unpacked_samples_it = (
+                    # this duplicates the unpacked samples
+                    {**unpacked_sample, **features_to_duplicate}
+                    for unpacked_sample in unpacked_samples_it
+                )
+
+            yield from unpacked_samples_it

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -21,7 +21,7 @@ class MockMapper(SingleBaseMapper):
         self.stage = stage
 
     def transform(self, data: dict) -> dict:
-        return {'stage': (data.get('stage', []) + [self.stage])}
+        return {"stage": (data.get("stage", []) + [self.stage])}
 
     def __eq__(self, __o: object) -> bool:
         """Check if two mappers are equal; useful to
@@ -68,7 +68,7 @@ class TestPipeline(unittest.TestCase):
         """Test a full pipeline"""
         pipeline = MockMapper(1) >> MockMapper(2) >> MockMapper(3)
 
-        dataset = Dataset([{'stage': [0]}])
+        dataset = Dataset([{"stage": [0]}])
         dataset = pipeline.map(dataset)
 
-        self.assertEqual(dataset[0]['stage'], [0, 1, 2, 3])
+        self.assertEqual(dataset[0]["stage"], [0, 1, 2, 3])

--- a/tests/test_unpacking_mapper.py
+++ b/tests/test_unpacking_mapper.py
@@ -1,0 +1,52 @@
+import unittest
+
+from smashed.interfaces.simple import Dataset, UnpackingMapper
+
+
+class TestUnpackingMapper(unittest.TestCase):
+    def test_unpack_single(self):
+        mapper = UnpackingMapper()
+        dataset = Dataset([{"a": [0, 1, 2, 3]}, {"a": [4, 5]}])
+        dataset = mapper.map(dataset)
+
+        self.assertEqual(len(dataset), 6)
+        for i in range(6):
+            self.assertEqual(dataset[i], {"a": i})
+
+    def test_unpack_multiple(self):
+        mapper = UnpackingMapper()
+        dataset = Dataset(
+            [
+                {"a": [0.1, 1.1, 2.1, 3.1], "b": [0.2, 1.2, 2.2, 3.2]},
+                {"a": [4.1, 5.1], "b": [4.2, 5.2]},
+            ]
+        )
+        dataset = mapper.map(dataset)
+
+        self.assertEqual(len(dataset), 6)
+        for i in range(6):
+            self.assertEqual(
+                dataset[i], {"a": float(f"{i}.1"), "b": float(f"{i}.2")}
+            )
+
+    def test_unpack_multiple_while_skipping_fields(self):
+        mapper = UnpackingMapper(
+            fields_to_unpack=["a"], ignored_behavior="drop"
+        )
+        dataset = Dataset(
+            [{"a": [0, 1, 2, 3], "b": "hello"}, {"a": [4, 5], "b": "hello"}]
+        )
+
+        dropped_dataset = mapper.map(dataset)
+        self.assertEqual(len(dropped_dataset), 6)
+        for i in range(6):
+            self.assertEqual(dropped_dataset[i], {"a": i})
+            self.assertFalse("b" in dropped_dataset[i])
+
+        mapper = UnpackingMapper(
+            fields_to_unpack=["a"], ignored_behavior="repeat"
+        )
+        repeated_dataset = mapper.map(dataset)
+        self.assertEqual(len(repeated_dataset), 6)
+        for i in range(6):
+            self.assertEqual(repeated_dataset[i], {"a": i, "b": "hello"})


### PR DESCRIPTION
`UnpackingMapper` turns a sample with sequences into multiple samples, each with a single sequence. 