### PR TITLE
Added new mappers for collation + batching + tensor conversion

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = smashed
-version = 0.1.5
+version = 0.1.6
 author = Allen Institute for Artificial Intelligence
 author_email = contact@allenai.org
 description = Sequential MAppers for Sequences of HEterogeneous Dictionaries

--- a/smashed/interfaces/huggingface.py
+++ b/smashed/interfaces/huggingface.py
@@ -50,6 +50,11 @@ __all__ = [
     "OneVsOtherAnnotatorMapper",
     "ChangeFieldsMapper",
     "ValidUnicodeMapper",
+    "FixedBatchSizeMapper",
+    "CollatorMapper",
+    "FromTokenizerCollatorMapper",
+    "Python2TorchMapper",
+    "Torch2PythonMapper",
 ]
 
 
@@ -229,11 +234,6 @@ class ValidUnicodeMapper(
     HuggingFaceDatasetsInterfaceMapper, tokenize.ValidUnicodeMapper
 ):
     ...
-
-
-# from ..mappers.batchers import FixedBatchSizeMapper
-# from ..mappers.collators import CollatorMapper, FromTokenizerCollatorMapper
-# from ..mappers.converters import Python2TorchMapper, Torch2PythonMapper
 
 
 class FixedBatchSizeMapper(

--- a/smashed/interfaces/huggingface.py
+++ b/smashed/interfaces/huggingface.py
@@ -1,13 +1,23 @@
 from abc import ABCMeta
-from typing import Any, Dict, List, Tuple, TypeVar
+from typing import Any, Dict, Iterable, List, Tuple, TypeVar
+
+import torch
 
 from ..base.mapper import (
-    AbstractBaseMapper,
     BatchedBaseMapper,
+    DatasetInterfaceMapper,
     SingleBaseMapper,
 )
 from ..base.types import TransformBatchType
-from ..mappers import fields, multiseq, shape, tokenize
+from ..mappers import (
+    batchers,
+    collators,
+    converters,
+    fields,
+    multiseq,
+    shape,
+    tokenize,
+)
 from ..mappers.contrib import sse
 from ..utils import requires
 
@@ -44,7 +54,7 @@ __all__ = [
 
 
 class HuggingFaceDatasetsInterfaceMapper(
-    AbstractBaseMapper, metaclass=ABCMeta
+    DatasetInterfaceMapper, metaclass=ABCMeta
 ):
     def _batch_transform(
         self: "HuggingFaceDatasetsInterfaceMapper", data: TransformBatchType
@@ -78,28 +88,39 @@ class HuggingFaceDatasetsInterfaceMapper(
 
         return transformed_batch
 
-    def map(self, dataset: HfDatasetType, **map_kwargs: Any) -> HfDatasetType:
+    def get_dataset_fields(
+        self: "HuggingFaceDatasetsInterfaceMapper", dataset: HfDatasetType
+    ) -> Iterable[str]:
+        return dataset.features.keys()
 
-        for field in self.input_fields:
-            if field not in dataset.features:
-                raise ValueError(f"Field {field} not found in dataset")
+    def map(
+        self: "HuggingFaceDatasetsInterfaceMapper",
+        dataset: HfDatasetType,
+        **map_kwargs: Any
+    ) -> HfDatasetType:
+
+        self.check_dataset_fields(
+            provided_fields=self.get_dataset_fields(dataset),
+            expected_fields=self.input_fields,
+        )
 
         if isinstance(self, BatchedBaseMapper):
-            dataset = dataset.map(
+            transformed_dataset = dataset.map(
                 self._batch_transform, **{**map_kwargs, "batched": True}
             )
         elif isinstance(self, SingleBaseMapper):
-            dataset = dataset.map(self.transform, **map_kwargs)
+            transformed_dataset = dataset.map(self.transform, **map_kwargs)
         else:
             raise TypeError(
                 "Mapper must inherit a SingleBaseMapper or a BatchedBaseMapper"
             )
 
-        for field in self.input_fields:
-            if field not in dataset.features:
-                raise ValueError(f"Field {field} not found in dataset")
+        self.check_dataset_fields(
+            provided_fields=self.get_dataset_fields(transformed_dataset),
+            expected_fields=self.output_fields,
+        )
 
-        return dataset
+        return transformed_dataset
 
 
 class TokensSequencesPaddingMapper(
@@ -208,3 +229,55 @@ class ValidUnicodeMapper(
     HuggingFaceDatasetsInterfaceMapper, tokenize.ValidUnicodeMapper
 ):
     ...
+
+
+# from ..mappers.batchers import FixedBatchSizeMapper
+# from ..mappers.collators import CollatorMapper, FromTokenizerCollatorMapper
+# from ..mappers.converters import Python2TorchMapper, Torch2PythonMapper
+
+
+class FixedBatchSizeMapper(
+    HuggingFaceDatasetsInterfaceMapper, batchers.FixedBatchSizeMapper
+):
+    ...
+
+
+class CollatorMapper(
+    HuggingFaceDatasetsInterfaceMapper, collators.CollatorMapper
+):
+    ...
+
+
+class FromTokenizerCollatorMapper(
+    HuggingFaceDatasetsInterfaceMapper, collators.FromTokenizerCollatorMapper
+):
+    ...
+
+
+class Python2TorchMapper(
+    HuggingFaceDatasetsInterfaceMapper, converters.Python2TorchMapper
+):
+    def __init__(self: "Python2TorchMapper", *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+        if self.device and self.device != torch.device("cpu"):
+            raise RuntimeError(
+                '"device" argument is not supported for Python2TorchMapper'
+                " when using Huggingface datasets."
+            )
+        if len(self.field_cast_map) > 0:
+            raise RuntimeError(
+                '"field_cast_map" argument is not supported for '
+                "Python2TorchMapper when using Huggingface datasets."
+            )
+
+    def map(self, dataset: HfDatasetType, **map_kwargs: Any) -> HfDatasetType:
+        return dataset.with_format("torch")
+
+
+class Torch2PythonMapper(
+    HuggingFaceDatasetsInterfaceMapper, converters.Torch2PythonMapper
+):
+    def map(self, dataset: HfDatasetType, **_: Any) -> HfDatasetType:
+        # this changes the logic for converting to a python object
+        # to map to apis for HuggingFace datasets
+        return dataset.with_format(None)

--- a/smashed/interfaces/simple.py
+++ b/smashed/interfaces/simple.py
@@ -1,4 +1,7 @@
+from ..mappers.batchers import FixedBatchSizeMapper
+from ..mappers.collators import CollatorMapper, FromTokenizerCollatorMapper
 from ..mappers.contrib.sse import OneVsOtherAnnotatorMapper
+from ..mappers.converters import Python2TorchMapper, Torch2PythonMapper
 from ..mappers.fields import ChangeFieldsMapper, MakeFieldMapper
 from ..mappers.multiseq import (
     AttentionMaskSequencePaddingMapper,
@@ -32,6 +35,11 @@ __all__ = [
     "ChangeFieldsMapper",
     "MakeFieldMapper",
     "ValidUnicodeMapper",
+    "FixedBatchSizeMapper",
+    "CollatorMapper",
+    "FromTokenizerCollatorMapper",
+    "Python2TorchMapper",
+    "Torch2PythonMapper",
 ]
 
 

--- a/smashed/mappers/batchers.py
+++ b/smashed/mappers/batchers.py
@@ -1,0 +1,53 @@
+from typing import Iterable
+
+from ..base.mapper import BatchedBaseMapper
+from ..base.types import TransformElementType
+
+
+class FixedBatchSizeMapper(BatchedBaseMapper):
+    def __init__(
+        self: "FixedBatchSizeMapper",
+        batch_size: int,
+        keep_last: bool = True,
+    ) -> None:
+        """A very simple mapper that batches samples into fixed-size batches.
+
+        Args:
+            batch_size (int): The number of samples in each batch.
+            keep_last (bool, optional): Whether to keep the last batch if it
+                is not full. Defaults to True.
+        """
+        try:
+            batch_size = int(batch_size)
+            assert batch_size > 0
+        except Exception:
+            raise ValueError(
+                f"batch_size must be a positive integer, not {batch_size}"
+            )
+
+        if not isinstance(keep_last, bool):
+            raise ValueError(f"keep_last must be a boolean, not {keep_last}")
+
+        self.batch_size = batch_size
+        self.keep_last = keep_last
+        super().__init__()
+
+    def transform(
+        self: "FixedBatchSizeMapper", data: Iterable[TransformElementType]
+    ) -> Iterable[TransformElementType]:
+        accumulator = None
+        counter = 0
+        for sample in data:
+            if accumulator is None:
+                accumulator = {k: [v] for k, v in sample.items()}
+            else:
+                [accumulator[k].append(v) for k, v in sample.items()]
+            counter += 1
+
+            if counter == self.batch_size:
+                yield accumulator
+                accumulator = None
+                counter = 0
+
+        if self.keep_last and accumulator is not None:
+            yield accumulator

--- a/smashed/mappers/collators.py
+++ b/smashed/mappers/collators.py
@@ -1,0 +1,152 @@
+from collections import abc
+from itertools import chain
+from typing import Dict, Mapping, Optional, Sequence
+
+import torch
+import torch.nn.functional as F
+from transformers.tokenization_utils_base import PreTrainedTokenizerBase
+
+from ..base.mapper import SingleBaseMapper
+
+
+class CollatorMapper(SingleBaseMapper):
+    def __init__(
+        self: "CollatorMapper",
+        fields_pad_ids: Optional[Mapping[str, int]] = None,
+        unk_fields_pad_id: Optional[int] = None,
+    ):
+        """A collator mapper that collates sequences of n tensors into a single
+        tensor of shape (n, ...) where ... is the maximum size of the
+        sequences. Uses the values passed to fields_pad_ids to determine
+        how to pad each field.
+
+        If used with a Pytorch DataLoader, the collator mapper must be
+        called as follows:
+
+        >>> collator = CollatorMapper(...)
+        >>> data_loader = DataLoader(..., collate_fn=collator.transform)
+
+        Args:
+            fields_pad_ids (Mapping[str, int], optional): A mapping from field
+                names to the padding value to use for that field. If not
+                provided, the mapper will fail unless the unk_fields_pad_id
+                attribute is set.
+            unk_fields_pad_id (int, optional): The padding value to use for
+                any field that is not in fields_pad_ids. If not provided, an
+                error will be raised if a field is not in fields_pad_ids.
+        """
+        self.fields_pad_ids = fields_pad_ids or {}
+        self.unk_fields_pad_id = unk_fields_pad_id
+        super().__init__()
+
+    def _get_padding_value(self, field_name: str) -> int:
+        if field_name in self.fields_pad_ids:
+            return self.fields_pad_ids[field_name]
+        elif self.unk_fields_pad_id is not None:
+            return self.unk_fields_pad_id
+        else:
+            raise ValueError(
+                f"Must specify a padding value for field {field_name}"
+                f"or provide a extra_fields_padding_id attribute to "
+                "the mapper to handle unrecognized fields"
+            )
+
+    @staticmethod
+    def _pad(
+        sequence: Sequence[torch.Tensor], pad_value: int, dim: int = 0
+    ) -> torch.Tensor:
+
+        # make sure type of input is right
+        if not (
+            isinstance(sequence, abc.Sequence)
+            and all(isinstance(elem, torch.Tensor) for elem in sequence)
+        ):
+            raise ValueError(
+                "Each element to collate must be a sequence of torch.Tensor, "
+                f"not {type(sequence)}"
+            )
+
+        # the `view` is because we need to add a new dimension as the
+        # dimension alongside which we batch
+        sequence = [torch.unsqueeze(tensor, dim=dim) for tensor in sequence]
+
+        max_lengths = tuple(max(t) for t in zip(*(t.size() for t in sequence)))
+
+        # https://pytorch.org/docs/stable/generated/torch.nn.functional.pad
+        # according to that page, we need to create pad shapes is reverse.
+        pad_shapes = tuple(
+            tuple(
+                chain.from_iterable(
+                    (0, m - s)
+                    for s, m in zip(t.size()[::-1], max_lengths[::-1])
+                )
+            )
+            # we do padding shapes for each tensor
+            for t in sequence
+        )
+        # call each pad on each of the tensors with the appropriate padding
+        to_stack = tuple(
+            F.pad(tensor, pad, mode="constant", value=pad_value)
+            for tensor, pad in zip(sequence, pad_shapes)
+        )
+
+        return torch.cat(to_stack, dim=dim)
+
+    def transform(
+        self: "CollatorMapper", data: Dict[str, Sequence[torch.Tensor]]
+    ) -> Dict[str, torch.Tensor]:
+
+        collated_data = {
+            field_name: self._pad(
+                sequence=list_of_tensors,
+                pad_value=self._get_padding_value(field_name),
+            )
+            for field_name, list_of_tensors in data.items()
+        }
+        return collated_data
+
+
+class FromTokenizerCollatorMapper(CollatorMapper):
+    def __init__(
+        self,
+        tokenizer: PreTrainedTokenizerBase,
+        fields_pad_ids: Optional[Mapping[str, int]] = None,
+        unk_fields_pad_id: Optional[int] = None,
+    ):
+        """A collator mapper that collates sequences of n tensors into a
+        single tensor of shape (n, ...) where ... is the maximum size of the
+        sequences. Uses the provided tokenizer to determine how to pad common
+        fields for NLP tasks, such as `input_ids`, `attention_mask`,
+        `token_type_ids`, etc. Padding values for further fields can be
+        provided in the `fields_pad_ids` argument.
+
+        If used with a Pytorch DataLoader, the collator mapper must be
+        called as follows:
+        >>> tokenizer = AutoTokenizer.from_pretrained(...)
+        >>> collator = FromTokenizerCollatorMapper(tokenizer, ...)
+        >>> data_loader = DataLoader(..., collate_fn=collator.transform)
+
+        Args:
+            tokenizer (PreTrainedTokenizerBase): The tokenizer to use to pad
+                common fields.
+            fields_pad_ids (Mapping[str, int], optional): A mapping from field
+                names to the padding value to use for that field.
+            unk_fields_pad_id (int, optional): The padding value to use for
+                any field that is not recognized. If not provided, an error
+                will be raised if a field is not recognized.
+        """
+
+        fields_pad_ids = {
+            "input_ids": tokenizer.pad_token_id or 0,
+            "attention_mask": 0,
+            "token_type_ids": tokenizer.pad_token_type_id or 0,
+            "overflow_to_sample_mapping": 0,
+            "special_tokens_mask": 0,
+            "offset_mapping": 0,
+            "length": 0,
+            **(fields_pad_ids or {}),
+        }
+        super().__init__(
+            unk_fields_pad_id=unk_fields_pad_id,
+            fields_pad_ids=fields_pad_ids,
+        )

--- a/smashed/mappers/converters.py
+++ b/smashed/mappers/converters.py
@@ -1,0 +1,81 @@
+from typing import Any, Dict, Mapping, Optional, Union
+
+import torch
+
+from ..base.mapper import SingleBaseMapper
+from ..base.types import TransformElementType
+
+
+class Python2TorchMapper(SingleBaseMapper):
+
+    __slots__ = ["field_cast_map", "device"]
+    field_cast_map: Dict[str, torch.dtype]
+    device: Union[torch.device, None]
+
+    def __init__(
+        self: "Python2TorchMapper",
+        field_cast_map: Optional[Mapping[str, Union[str, torch.dtype]]] = None,
+        device: Optional[Union[torch.device, str]] = None,
+    ) -> None:
+        """Mapper that converts Python types to Torch types. It can optionally
+        cast the values of a field to a specific type, and move to a specific
+        device.
+
+        Args:
+            field_cast_map (Mapping[str, Union[str, torch.dtype]], optional):
+                Mapping from field names to the types to cast the values to.
+                Defaults to None, which means no casting occurs.
+            device (Union[torch.device, str], optional): Device to move the
+                tensors to. Defaults to None, which means no moving occurs.
+        """
+        self.device = torch.device(device) if device else None
+
+        self.field_cast_map = {
+            field_name: self._get_dtype(field_type)
+            for field_name, field_type in (field_cast_map or {}).items()
+        }
+        super().__init__(
+            input_fields=list(self.field_cast_map.keys()),
+            output_fields=list(self.field_cast_map.keys()),
+        )
+
+    @staticmethod
+    def _get_dtype(dtype: Any) -> torch.dtype:
+
+        if isinstance(dtype, str):
+            dtype = getattr(torch, dtype, None)
+            if dtype is None:
+                raise ValueError(f"Unknown dtype {dtype}")
+
+        if not isinstance(dtype, torch.dtype):
+            raise ValueError(f"{dtype} is not a torch dtype")
+
+        return dtype
+
+    def transform(self, data: TransformElementType) -> TransformElementType:
+        return {
+            # .to(type) and .to(device) will return the original tensor if
+            # the type and device are the same/None; this is because
+            # for any torch.Tensor t, hash(t) == hash(t.to(None).to(None))
+            field_name: torch.tensor(field_value)
+            .to(self.field_cast_map.get(field_name, None))
+            .to(self.device)
+            for field_name, field_value in data.items()
+        }
+
+
+class Torch2PythonMapper(SingleBaseMapper):
+    def __init__(self: "Torch2PythonMapper") -> None:
+        """Mapper that converts Torch types to Python types. It relies on
+        function `.tolist()` to convert the tensor to a list. It additionally
+        moves the tensor to the CPU before converting it.
+        """
+        super().__init__()
+
+    def transform(
+        self: "Torch2PythonMapper", data: Dict[str, torch.Tensor]
+    ) -> TransformElementType:
+        return {
+            field_name: field_value.cpu().tolist()
+            for field_name, field_value in data.items()
+        }

--- a/tests/test_batchers.py
+++ b/tests/test_batchers.py
@@ -18,11 +18,15 @@ class TestBatchers(unittest.TestCase):
         ]
         mapper = FixedBatchSizeMapper(batch_size=3)
         batched_dataset = mapper.map(dataset)
+
         self.assertEqual(len(batched_dataset), 4)
-        self.assertEqual(len(batched_dataset[0]), 3)
-        self.assertEqual(len(batched_dataset[1]), 3)
-        self.assertEqual(len(batched_dataset[2]), 3)
-        self.assertEqual(len(batched_dataset[3]), 1)
+
+        for key in "a b c".split():
+            self.assertEqual(len(batched_dataset[0][key]), 3)
+            self.assertEqual(len(batched_dataset[1][key]), 3)
+            self.assertEqual(len(batched_dataset[2][key]), 3)
+            self.assertEqual(len(batched_dataset[3][key]), 1)
+
         self.assertEqual(
             batched_dataset[0],
             {

--- a/tests/test_batchers.py
+++ b/tests/test_batchers.py
@@ -1,0 +1,33 @@
+"""
+Unit test for making batches from a dataset
+
+Author: Luca Soldaini
+Email:  lucas@allenai.org
+"""
+
+import unittest
+
+from smashed.mappers.batchers import FixedBatchSizeMapper
+
+
+class TestBatchers(unittest.TestCase):
+    def test_batchers(self):
+        dataset = [
+            {k: [i, v] for v, k in enumerate("a b c".split())}
+            for i in range(10)
+        ]
+        mapper = FixedBatchSizeMapper(batch_size=3)
+        batched_dataset = mapper.map(dataset)
+        self.assertEqual(len(batched_dataset), 4)
+        self.assertEqual(len(batched_dataset[0]), 3)
+        self.assertEqual(len(batched_dataset[1]), 3)
+        self.assertEqual(len(batched_dataset[2]), 3)
+        self.assertEqual(len(batched_dataset[3]), 1)
+        self.assertEqual(
+            batched_dataset[0],
+            {
+                "a": [[0, 0], [1, 0], [2, 0]],
+                "b": [[0, 1], [1, 1], [2, 1]],
+                "c": [[0, 2], [1, 2], [2, 2]],
+            },
+        )

--- a/tests/test_collators.py
+++ b/tests/test_collators.py
@@ -1,0 +1,68 @@
+"""
+Unit test for collating sequences of uneven length
+
+Author: Luca Soldaini
+Email:  lucas@allenai.org
+"""
+
+import unittest
+
+from transformers.models.auto.tokenization_auto import AutoTokenizer
+
+from smashed.mappers.batchers import FixedBatchSizeMapper
+from smashed.mappers.collators import (
+    CollatorMapper,
+    FromTokenizerCollatorMapper,
+)
+from smashed.mappers.converters import Python2TorchMapper
+
+
+class TestCollators(unittest.TestCase):
+    def test_base_collator(self):
+        dataset = [
+            {"a": [1, 2, 3], "b": [11, 12]},
+            {"a": [4, 5], "b": [13]},
+            {"a": [6, 7, 8, 9, 10], "b": [14]},
+        ]
+        pipeline = (
+            Python2TorchMapper()
+            >> FixedBatchSizeMapper(batch_size=3)
+            >> CollatorMapper(fields_pad_ids={"a": -1, "b": -2})
+        )
+
+        collated_dataset = pipeline.map(dataset)
+        self.assertEqual(len(collated_dataset), 1)
+        self.assertEqual(collated_dataset[0]["a"].shape, (3, 5))
+        self.assertEqual(collated_dataset[0]["b"].shape, (3, 2))
+        self.assertEqual((collated_dataset[0]["a"] == -1).sum(), 5)
+        self.assertEqual((collated_dataset[0]["b"] == -2).sum(), 2)
+
+    def test_from_tokenizer_collator(self):
+        tokenizer = AutoTokenizer.from_pretrained("roberta-base")
+
+        sent_first = "I am a sentence"  # len 4 when tokenized
+        sent_last = "I am a pterodactyl"  # len 8 when tokenized
+
+        dataset = [tokenizer(sent_first), tokenizer(sent_last)]
+
+        pipeline = (
+            Python2TorchMapper()
+            >> FixedBatchSizeMapper(batch_size=2)
+            >> FromTokenizerCollatorMapper(tokenizer)
+        )
+        collated_dataset = pipeline.map(dataset)
+
+        self.assertEqual(len(collated_dataset), 1)
+
+        # check if we padded to the length of the 2nd sentence
+        # (which is the longest at 8 subwords) + 2 (for CLS and SEP)
+        self.assertEqual(collated_dataset[0]["input_ids"].shape, (2, 8 + 2))
+        # the first sequence is 4 subwords long, while the second is 8;
+        # therefore, there should be 4 padding tokens in the collated batch
+        self.assertEqual(
+            (collated_dataset[0]["input_ids"] == tokenizer.pad_token_id).sum(),
+            4,
+        )
+
+        # same thing except attention mask uses 0 for padding
+        self.assertEqual((collated_dataset[0]["attention_mask"] == 0).sum(), 4)

--- a/tests/test_tokenize_mappers.py
+++ b/tests/test_tokenize_mappers.py
@@ -33,22 +33,20 @@ class TestValidUnicodeMapper(unittest.TestCase):
             ],
             replace_token="[UNK]",
         )
-        dataset = Dataset(
-            [
-                {
-                    "tokens": [
-                        "This",
-                        "example",
-                        "has",
-                        "bad",
-                        "\uf02a",
-                        "\uf02a\u00ad",
-                        "Modalities\uf02a",
-                    ]
-                }
-            ]
-        )
-        new_dataset = mapper.map(dataset)
+        dataset = [
+            {
+                "tokens": [
+                    "This",
+                    "example",
+                    "has",
+                    "bad",
+                    "\uf02a",
+                    "\uf02a\u00ad",
+                    "Modalities\uf02a",
+                ]
+            }
+        ]
+        new_dataset: list = mapper.map(dataset)  # type: ignore
         self.assertListEqual(
             new_dataset,
             [


### PR DESCRIPTION
This PR adds the following Mappers:

- `FixedBatchSizeMapper`: Create batches of given batch size
- `CollatorMapper`: Collate sequences of Torch tensors into a properly padded tensor.
- `FromTokenizerCollatorMapper`: Same as `CollatorMapper`, but uses a HuggingFace tokenizer to figure out what to use for some common fields to pad. 
- `Python2TorchMapper`: Converts a mapper with values in Python types into a tensor. 
- `Torch2PythonMapper`: The opposite of the mapper above