### PR TITLE
Prompting Mappers and the return of chain

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,3 +57,6 @@ site/
 
 # remove temp dir
 tmp/
+
+# locks
+*.lock

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ![Colorful logo of smashed. It is the word smashed written in a playful font that vaguely looks like pipes.](https://github.com/allenai/smashed/raw/main/resources/smashed.png)
 
-**S**equential **MA**ppers for **S**equences of **HE**terogeneous **D**ictionaries is a set of Python interfaces designed to apply transformations to samples in datasets, which are often implemented as sequences of dictionaries. To start, run 
+**S**equential **MA**ppers for **S**equences of **HE**terogeneous **D**ictionaries is a set of Python interfaces designed to apply transformations to samples in datasets, which are often implemented as sequences of dictionaries. To start, run
 
 ```bash
 pip install smashed
@@ -172,3 +172,11 @@ To contribute to SMASHED, make sure to:
     5. *Tests:* `pytest -v --color=yes tests/` (Should return no error)
 8. Commit, push, and create a pull request.
 9. Tag `soldni` to review the PR.
+
+### A note about versioning
+
+SMASHED follows [Semantic Versioning](https://semver.org/). In short, this means that the version number is MAJOR.MINOR.PATCH, where:
+
+- MAJOR version when you make incompatible API changes,
+- MINOR version when you add functionality in a backwards compatible manner; adding a mapper typically falls under this category, and
+- PATCH version when you make backwards compatible bug fixes.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,8 +10,8 @@ license = {text = "Apache-2.0"}
 readme = "README.md"
 requires-python = ">=3.8"
 dependencies = [
-    "torch >= 1.9",
-    "transformers >= 4.5",
+    "torch>=1.9",
+    "transformers>=4.5",
     "necessary>=0.2.3",
     "trouting>=0.2.2",
     "ftfy>=6.1.1",
@@ -60,8 +60,8 @@ datasets = [
   "datasets>=2.4.0"
 ]
 torchdata = [
-  "torch >= 1.12.1",
-  "torchdata >= 0.4.1"
+  "torch>=1.12.1",
+  "torchdata>=0.4.1"
 ]
 all = [
     "smashed[dev]",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "smashed"
-version = "0.4.1"
+version = "0.5.0"
 description = "Sequential MAppers for Sequences of HEterogeneous Dictionaries is a set of Python interfaces designed to apply transformations to samples in datasets, which are often implemented as sequences of dictionaries."
 authors = [
     {name = "Allen Institute for Artificial Intelligence", email = "contact@allenai.org" },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "smashed"
-version = "0.3.0"
+version = "0.4.0"
 description = "Sequential MAppers for Sequences of HEterogeneous Dictionaries is a set of Python interfaces designed to apply transformations to samples in datasets, which are often implemented as sequences of dictionaries."
 authors = [
     {name = "Allen Institute for Artificial Intelligence", email = "contact@allenai.org" },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "smashed"
-version = "0.4.0"
+version = "0.4.1"
 description = "Sequential MAppers for Sequences of HEterogeneous Dictionaries is a set of Python interfaces designed to apply transformations to samples in datasets, which are often implemented as sequences of dictionaries."
 authors = [
     {name = "Allen Institute for Artificial Intelligence", email = "contact@allenai.org" },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "smashed"
-version = "0.5.0"
+version = "0.4.0"
 description = "Sequential MAppers for Sequences of HEterogeneous Dictionaries is a set of Python interfaces designed to apply transformations to samples in datasets, which are often implemented as sequences of dictionaries."
 authors = [
     {name = "Allen Institute for Artificial Intelligence", email = "contact@allenai.org" },

--- a/src/smashed/__init__.py
+++ b/src/smashed/__init__.py
@@ -1,3 +1,6 @@
 from .utils import get_version
+from .utils import make_pipeline as pipeline
 
 __version__ = get_version()
+
+__all__ = ["pipeline"]

--- a/src/smashed/base/interfaces.py
+++ b/src/smashed/base/interfaces.py
@@ -110,11 +110,7 @@ class MapMethodInterfaceMixIn(AbstractBaseMapper):
         return transformed_batch
 
     @trouting
-    def map(  # type: ignore
-        self,
-        dataset: Any,
-        **map_kwargs: Any,
-    ) -> Any:
+    def map(self, dataset: Any, **map_kwargs: Any) -> Any:
         raise ValueError(
             f"I don't know how to map a dataset of type {type(dataset)}; "
             "interface not implemented."
@@ -137,11 +133,12 @@ class MapMethodInterfaceMixIn(AbstractBaseMapper):
                 the transform method. By default, this is empty; other
                 implementations may use this.
         """
-
         # explicitly casting to a boolean since this is all that is
         # supported by the simple mapper.
         # TODO[lucas]: maybe support specifying which fields to keep?
-        remove_columns = bool(map_kwargs.pop("remove_columns", False))
+        remove_columns = bool(map_kwargs.get("remove_columns", False))
+
+        print(remove_columns)
 
         if isinstance(dataset, abc.Sequence):
             self._check_fields_datasets(

--- a/src/smashed/base/interfaces.py
+++ b/src/smashed/base/interfaces.py
@@ -14,6 +14,7 @@ from typing import (
 )
 
 from necessary import necessary
+from torch._utils import classproperty
 from trouting import trouting
 
 from .abstract import (
@@ -34,6 +35,17 @@ with necessary("datasets", soft=True) as HUGGINGFACE_DATASET_AVAILABLE:
 
 
 class MapMethodInterfaceMixIn(AbstractBaseMapper):
+    """Mix-in class that implements the map method for all mappers
+    and various interfaces. Do not inherit from this class directly,
+    but use SingleBaseMapper/BatchedBaseMapper instead."""
+
+    @classproperty
+    def always_remove_columns(cls) -> bool:
+        """Whether this mapper should always remove its input columns
+        from the dataset. If False, the mapper will only remove columns
+        if the output columns are not a subset of the input columns."""
+        return False
+
     def _check_fields_datasets(
         self,
         provided_fields: Union[Iterable[str], None],
@@ -87,7 +99,7 @@ class MapMethodInterfaceMixIn(AbstractBaseMapper):
         keys = [k for k in data.keys()]
 
         # _index_fn ensures that, between when we unpack
-        # the sequence of samples in TrasformBatchType, and when we
+        # the sequence of samples in TransformBatchType, and when we
         # pack them into a list of dictionaries, we always get the
         # same order of features. This is important because we don't
         # want one feature value accidentally getting mapped to the
@@ -136,9 +148,10 @@ class MapMethodInterfaceMixIn(AbstractBaseMapper):
         # explicitly casting to a boolean since this is all that is
         # supported by the simple mapper.
         # TODO[lucas]: maybe support specifying which fields to keep?
-        remove_columns = bool(map_kwargs.get("remove_columns", False))
-
-        print(remove_columns)
+        remove_columns = (
+            bool(map_kwargs.get("remove_columns", False))
+            or self.always_remove_columns
+        )
 
         if isinstance(dataset, abc.Sequence):
             self._check_fields_datasets(
@@ -202,13 +215,25 @@ class MapMethodInterfaceMixIn(AbstractBaseMapper):
                 expected_fields=self.input_fields,
             )
 
+            if self.always_remove_columns:
+                remove_columns = list(dataset.features.keys())
+            else:
+                remove_columns = map_kwargs.get("remove_columns", [])
+
             if isinstance(self, AbstractBatchedBaseMapper):
                 transformed_dataset = dataset.map(
                     self._batch_transform_huggingface_datasets,
-                    **{**map_kwargs, "batched": True},  # type: ignore
+                    **{
+                        **map_kwargs,
+                        "batched": True,
+                        "remove_columns": remove_columns,
+                    },
                 )
             elif isinstance(self, AbstractSingleBaseMapper):
-                transformed_dataset = dataset.map(self.transform, **map_kwargs)
+                transformed_dataset = dataset.map(
+                    self.transform,
+                    **{**map_kwargs, "remove_columns": remove_columns},
+                )
             else:
                 raise TypeError(
                     "Mapper but be either a SingleBaseMapper or "

--- a/src/smashed/base/interfaces.py
+++ b/src/smashed/base/interfaces.py
@@ -52,6 +52,11 @@ class MapMethodInterfaceMixIn(AbstractBaseMapper):
         expected_fields: Sequence[str],
         reverse_membership_check: bool = False,
     ) -> None:
+        """Checks whether the provided fields are a subset of the
+        expected fields. If reverse_membership_check is True, checks
+        whether the provided fields are a superset of the expected
+        fields."""
+
         if provided_fields is None:
             return
 

--- a/src/smashed/base/mappers.py
+++ b/src/smashed/base/mappers.py
@@ -42,11 +42,22 @@ class PipelineFingerprintMixIn(AbstractBaseMapper):
         self.fingerprint = self._get_mapper_fingerprint()
         self.pipeline = None
 
-    def chain(self: P, next_mapper: "PipelineFingerprintMixIn") -> P:
-        """Create a pipeline by combining this mapper with another."""
+    def chain(
+        self: P, next_mapper: "PipelineFingerprintMixIn", inplace: bool = True
+    ) -> P:
+        """Create a pipeline by combining this mapper with another.
+
+        Args:
+            next_mapper (Mapper): The mapper to attach at the end of this
+                mapper or pipeline.
+            inplace (bool, optional): If True, the pipeline will be created
+                in place. If False, a new pipeline will be created. Defaults
+                to True.
+        """
 
         # create a copy of this mapper before attaching it to the next mapper
-        to_return = self.detach()
+        # unless inplace is True
+        to_return = self if inplace else self.detach()
 
         # if the current mapper is already attached to a pipeline, we need
         # to recursively merge the pipelines; otherwise, we can just attach
@@ -62,16 +73,16 @@ class PipelineFingerprintMixIn(AbstractBaseMapper):
         return to_return
 
     def __lshift__(self, prev_mapper: P) -> P:
-        """Create a pipeline by combining this mapper with another.
-        This is equivalent to other.chain(self), but with notation
+        """Create a pipeline by combining this mapper with another. This is
+        equivalent to other.chain(self, inplace=False), but with notation
         self << other."""
-        return prev_mapper.chain(self)
+        return prev_mapper.chain(self, inplace=False)
 
     def __rshift__(self: P, next_mapper: "PipelineFingerprintMixIn") -> P:
-        """Create a pipeline by combining this mapper with another.
-        This is equivalent to self.chain(other), but with notation
+        """Create a pipeline by combining this mapper with another. This is
+        equivalent to self.chain(other, inplace=False), but with notation
         self >> other."""
-        return self.chain(next_mapper)
+        return self.chain(next_mapper, inplace=False)
 
     def __repr__(self) -> str:
         """Return a string representation of this mapper."""

--- a/src/smashed/mappers/__init__.py
+++ b/src/smashed/mappers/__init__.py
@@ -8,7 +8,7 @@ from .collators import (
 )
 from .converters import Python2TorchMapper, Torch2PythonMapper
 from .debug import DebugBatchedMapper, DebugSingleMapper
-from .fields import ChangeFieldsMapper, MakeFieldMapper
+from .fields import ChangeFieldsMapper, MakeFieldMapper, RenameFieldsMapper
 from .filters import FilterMapper
 from .loaders import (
     CsvLoaderMapper,
@@ -65,6 +65,7 @@ __all__ = [
     "OneHotMapper",
     "PaddingMapper",
     "Python2TorchMapper",
+    "RenameFieldsMapper",
     "SequencesConcatenateMapper",
     "SingleValueToSequenceMapper",
     "StartCachingMapper",

--- a/src/smashed/mappers/__init__.py
+++ b/src/smashed/mappers/__init__.py
@@ -25,6 +25,12 @@ from .multiseq import (
     TokensSequencesPaddingMapper,
     TokenTypeIdsSequencePaddingMapper,
 )
+from .prompting import (
+    EncodeFieldsMapper,
+    FillEncodedPromptMapper,
+    FillTextPromptMapper,
+    TruncateNFieldsMapper,
+)
 from .shape import FlattenMapper, UnpackingMapper
 from .text import FtfyMapper
 from .tokenize import PaddingMapper, TokenizerMapper, ValidUnicodeMapper
@@ -38,7 +44,10 @@ __all__ = [
     "CsvLoaderMapper",
     "DebugBatchedMapper",
     "DebugSingleMapper",
+    "EncodeFieldsMapper",
     "EndCachingMapper",
+    "FillEncodedPromptMapper",
+    "FillTextPromptMapper",
     "FilterMapper",
     "FixedBatchSizeMapper",
     "FlattenMapper",
@@ -64,6 +73,7 @@ __all__ = [
     "TokensSequencesPaddingMapper",
     "TokenTypeIdsSequencePaddingMapper",
     "Torch2PythonMapper",
+    "TruncateNFieldsMapper",
     "UnpackingMapper",
     "ValidUnicodeMapper",
 ]

--- a/src/smashed/mappers/fields.py
+++ b/src/smashed/mappers/fields.py
@@ -66,21 +66,32 @@ class RenameFieldsMapper(SingleBaseMapper):
     def always_remove_columns(cls) -> bool:
         return True
 
-    def __init__(self, rename_fields_map: Dict[str, str]):
+    def __init__(
+        self,
+        rename_fields_map: Dict[str, str],
+        remove_rest: bool = False
+    ):
         """
         Args:
             rename_fields_map (Dict[str, str]): Mapping from old field name
                 to new field name.
+            remove_rest (bool, optional): Whether to remove fields that are
+                not in the rename_fields_map. Defaults to False.
         """
 
         self.rename_fields_map = rename_fields_map
+        self.remove_rest = remove_rest
         super().__init__(
             input_fields=list(rename_fields_map.keys()),
             output_fields=list(rename_fields_map.values()),
         )
 
     def transform(self, data: TransformElementType) -> TransformElementType:
-        return {self.rename_fields_map.get(k, k): v for k, v in data.items()}
+        return {
+            self.rename_fields_map.get(k, k): v
+            for k, v in data.items()
+            if k in self.rename_fields_map or not self.remove_rest
+        }
 
 
 class MakeFieldMapper(SingleBaseMapper):

--- a/src/smashed/mappers/fields.py
+++ b/src/smashed/mappers/fields.py
@@ -67,9 +67,7 @@ class RenameFieldsMapper(SingleBaseMapper):
         return True
 
     def __init__(
-        self,
-        rename_fields_map: Dict[str, str],
-        remove_rest: bool = False
+        self, rename_fields_map: Dict[str, str], remove_rest: bool = False
     ):
         """
         Args:

--- a/src/smashed/mappers/fields.py
+++ b/src/smashed/mappers/fields.py
@@ -1,7 +1,7 @@
-from typing import TYPE_CHECKING, Any, List, Optional, Sequence, TypeVar
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, TypeVar
 
 from necessary import necessary
-from trouting import trouting
+from torch._utils import classproperty
 
 from ..base import SingleBaseMapper, TransformElementType
 
@@ -16,14 +16,19 @@ with necessary("datasets", soft=True) as HUGGINGFACE_DATASET_AVAILABLE:
 
 
 class ChangeFieldsMapper(SingleBaseMapper):
+    """Mapper that removes some of the fields in a dataset.
+    Either `keep_fields` or `drop_fields` must be specified, but not both."""
+
+    @classproperty
+    def always_remove_columns(cls) -> bool:
+        return True
+
     def __init__(
         self,
         keep_fields: Optional[List[str]] = None,
         drop_fields: Optional[List[str]] = None,
     ):
-        """Mapper that removes some of the fields in a dataset.
-        Either `keep_fields` or `drop_fields` must be specified, but not both.
-
+        """
         Args:
             keep_fields (List[str]): Fields to keep, all other fields
                 are dropped. Defaults to [].
@@ -39,44 +44,6 @@ class ChangeFieldsMapper(SingleBaseMapper):
 
         super().__init__(input_fields=drop_fields, output_fields=keep_fields)
 
-    @trouting
-    def map(  # type: ignore
-        self,
-        dataset: Any,
-        **map_kwargs: Any,
-    ) -> Any:
-        return super().map(dataset, **map_kwargs)
-
-    @map.add_interface(dataset=list)
-    def map_list_of_dicts(
-        self,
-        dataset: Sequence[TransformElementType],
-        **map_kwargs: Any,
-    ) -> Sequence[TransformElementType]:
-        """If the dataset is a list of dicts, we need to make sure that
-        all existing columns are removed."""
-        return super().map(dataset, remove_columns=True, **map_kwargs)
-
-    if HUGGINGFACE_DATASET_AVAILABLE:
-
-        @map.add_interface(dataset=(Dataset, IterableDataset))
-        def map_huggingface_dataset(
-            self,
-            dataset: HuggingFaceDataset,
-            **map_kwargs: Any,
-        ) -> HuggingFaceDataset:
-            """If the dataset is a HuggingFace dataset, we also need to
-            make sure that existing columns get removed, but in this case
-            the mechanism is different."""
-
-            # mechanism to remove columns in huggingface datasets is
-            # slightly different than in list of dict datasets.
-            map_kwargs = {
-                "remove_columns": list(dataset.features.keys()),
-                **map_kwargs,
-            }
-            return super().map(dataset, **map_kwargs)
-
     def transform(self, data: TransformElementType) -> TransformElementType:
         if self.input_fields:
             new_data = {
@@ -90,6 +57,30 @@ class ChangeFieldsMapper(SingleBaseMapper):
             raise ValueError("Must specify `keep_fields` or `drop_fields`")
 
         return new_data
+
+
+class RenameFieldsMapper(SingleBaseMapper):
+    """Mapper that renames some of the fields batch"""
+
+    @classproperty
+    def always_remove_columns(cls) -> bool:
+        return True
+
+    def __init__(self, rename_fields_map: Dict[str, str]):
+        """
+        Args:
+            rename_fields_map (Dict[str, str]): Mapping from old field name
+                to new field name.
+        """
+
+        self.rename_fields_map = rename_fields_map
+        super().__init__(
+            input_fields=list(rename_fields_map.keys()),
+            output_fields=list(rename_fields_map.values()),
+        )
+
+    def transform(self, data: TransformElementType) -> TransformElementType:
+        return {self.rename_fields_map.get(k, k): v for k, v in data.items()}
 
 
 class MakeFieldMapper(SingleBaseMapper):

--- a/src/smashed/mappers/prompting.py
+++ b/src/smashed/mappers/prompting.py
@@ -23,7 +23,7 @@ class EncodeFieldsMapper(SingleBaseMapper):
         self,
         fields_to_encode: List[str],
         tokenizer: PreTrainedTokenizerBase,
-        is_split_into_words: Optional[bool] = False,
+        is_split_into_words: bool = False,
     ):
         """
         Args:

--- a/src/smashed/mappers/prompting.py
+++ b/src/smashed/mappers/prompting.py
@@ -96,6 +96,9 @@ class TruncateNFieldsMapper(SingleBaseMapper):
                 amount. Defaults to 'longest'.
         """
 
+        if len(fields_to_truncate) == 0:
+            raise ValueError("fields_to_truncate must be non-empty")
+
         if tokenizer is None and max_length is None:
             raise ValueError("Tokenizer or max_length must be provided.")
         elif max_length is None:
@@ -194,6 +197,7 @@ class TruncateNFieldsMapper(SingleBaseMapper):
         max_len = self.max_length - sum(
             len(data[field]) for field in self.fields_to_preserve
         )
+
         if self.strategy == "uniform":
             truncated_lens = self._find_truncated_lens_uniform(
                 lens=lens_to_truncate, max_len=max_len

--- a/src/smashed/mappers/prompting.py
+++ b/src/smashed/mappers/prompting.py
@@ -285,10 +285,10 @@ class FillEncodedPrompt(SingleBaseMapper, GetTokenizerOutputFieldsMixin):
         self._prefix = output_prefix
 
         self.bos_token_ids = (
-            [] if tokenizer.bos_token_id is None else [bos_token_id]
+            [] if tokenizer.bos_token_id is None else [tokenizer.bos_token_id]
         )
         self.eos_token_ids = (
-            [] if tokenizer.eos_token_id is None else [eos_token_id]
+            [] if tokenizer.eos_token_id is None else [tokenizer.eos_token_id]
         )
 
         self.prompt = PromptSegment.from_template(

--- a/src/smashed/mappers/prompting.py
+++ b/src/smashed/mappers/prompting.py
@@ -8,6 +8,13 @@ from transformers.tokenization_utils_base import PreTrainedTokenizerBase
 from ..base import SingleBaseMapper, TransformElementType
 from .tokenize import GetTokenizerOutputFieldsMixin
 
+__all__ = [
+    "EncodeFieldsMapper",
+    "FillEncodedPromptMapper",
+    "FillTextPromptMapper",
+    "TruncateNFieldsMapper",
+]
+
 
 class EncodeFieldsMapper(SingleBaseMapper):
     """Simply encodes the fields in the input data using the tokenizer."""
@@ -16,8 +23,19 @@ class EncodeFieldsMapper(SingleBaseMapper):
         self,
         fields_to_encode: List[str],
         tokenizer: PreTrainedTokenizerBase,
+        is_split_into_words: Optional[bool] = False,
     ):
+        """
+        Args:
+            fields_to_encode (List[str]): The name of the fields to encode.
+            tokenizer (PreTrainedTokenizerBase): A huggingface/tokenizer
+                to use for encoding.
+            is_split_into_words (bool, optional): Whether the input fields
+                are already split into words. Defaults to False.
+        """
+
         self.tokenizer = tokenizer
+        self.is_split_into_words = is_split_into_words
         self.fields_to_encode = set(fields_to_encode)
         super().__init__(
             input_fields=fields_to_encode,
@@ -32,6 +50,7 @@ class EncodeFieldsMapper(SingleBaseMapper):
                     add_special_tokens=False,
                     return_attention_mask=False,
                     return_token_type_ids=False,
+                    is_split_into_words=self.is_split_into_words,
                 ).input_ids
                 if name in self.fields_to_encode
                 else field

--- a/src/smashed/mappers/prompting.py
+++ b/src/smashed/mappers/prompting.py
@@ -1,14 +1,16 @@
+from bisect import bisect_right
 from dataclasses import dataclass
 from enum import Enum
+from math import floor
+import random
 import unicodedata
-from typing import Any, List, Optional, Sequence, Union
+from typing import Any, List, Literal, Optional, Sequence, Union, cast
 from string import Formatter
+
 
 from transformers.tokenization_utils_base import PreTrainedTokenizerBase
 
 from ..base import SingleBaseMapper, TransformElementType
-
-
 
 
 
@@ -56,30 +58,160 @@ class PromptSegment:
         return len(self.prompt_token_ids)
 
 
-class TruncateFieldsInPrompt(SingleBaseMapper, GetTokenizerOutputFieldsMixin):
+class EncodeFieldsMapper(SingleBaseMapper):
     def __init__(
         self,
-        template: str,
+        fields_to_encode: List[str],
         tokenizer: PreTrainedTokenizerBase,
-        max_length: Optional[int] = None,
-        truncation_strategy: str = "longest_first",
-        **tk_kwargs: Any,
-    ) -> None:
+    ):
         self.tokenizer = tokenizer
-
-        self.prompt = PromptSegment.from_template(
-            template=template,
-            tokenizer=tokenizer
-        )
-        self.max_length = (
-            max_length or tokenizer.model_max_length
-        ) - sum(len(p) for p in self.prompt)
-
-        output_fields = self.get_tokenizer_output_fields(**tk_kwargs)
+        self.fields_to_encode = set(fields_to_encode)
         super().__init__(
-            input_fields=[ps.field_name for ps in self.prompt if ps.field_name],
-            output_fields=output_fields
+            input_fields=fields_to_encode,
+            output_fields=fields_to_encode,
         )
 
     def transform(self, data: TransformElementType) -> TransformElementType:
-        ...
+        tokenized = {
+            name: (
+                self.tokenizer(
+                    field,
+                    add_special_tokens=False,
+                    return_attention_mask=False,
+                    return_token_type_ids=False,
+                ).input_ids if field in self.fields_to_encode else field
+            )
+            for name, field in data.items()
+        }
+        return tokenized
+
+
+class TruncateFieldsMapper(SingleBaseMapper):
+    def __init__(
+        self,
+        fields_to_truncate: List[str],
+        tokenizer: PreTrainedTokenizerBase,
+        max_length: Optional[int] = None,
+        penalty: int = 0,
+        strategy: Union[
+            Literal['longest'],
+            Literal['uniform'],
+         ] = 'longest',
+    ):
+        max_length = max_length or tokenizer.model_max_length
+        if not isinstance(max_length, int):
+            raise ValueError(
+                f"max_length must be an integer, not {type(max_length)}"
+            )
+
+        if strategy not in ('longest', 'uniform'):
+            raise ValueError(
+                "strategy must be one of 'longest' or 'uniform', "
+                f"not {strategy}"
+            )
+
+        self.tokenizer = tokenizer
+        self.fields_to_truncate = set(fields_to_truncate)
+        self.max_length = max_length - penalty
+        self.strategy = strategy
+        super().__init__(
+            input_fields=fields_to_truncate,
+            output_fields=fields_to_truncate,
+        )
+
+    @classmethod
+    def _find_truncated_lens_uniform(
+        cls, lens: List[int], max_len: int
+    ) -> List[int]:
+
+        reduction_fraction = max_len / sum(lens)
+
+        if reduction_fraction >= 1:
+            # no need to cut
+            return lens
+
+        # we will cut all sequences by the same amount
+        truncated = [floor(ls * reduction_fraction) for ls in lens]
+        return truncated
+
+    @classmethod
+    def _find_truncated_lens_longest(
+        cls, lens: List[int], max_len: int
+    ) -> List[int]:
+        """Cuts longest sequences first until we get a set of sequences
+        that is up to the maximum length."""
+
+        if sum(lens) <= max_len:
+            return lens
+
+        # this is how long sequences will be on average.
+        target_length = max_len // len(lens)
+
+        # these are the lengths that are above the target length;
+        # we need to figure out how much to cut them by by "redistributing"
+        # the length from (a) sequences that are below the target length
+        # and (b) any rounding errors from // above.
+        longer_than_average = [
+            ls - target_length if ls > target_length else 0
+            for ls in lens
+        ]
+        extra_len_to_redistribute = (
+            # we need to redistribute what we have lost in rounding...
+            max_len - target_length * len(lens)
+            # ... plus the extra saving
+            + sum(target_length - ls for ls in lens if ls < target_length)
+        )
+
+        # we actually leverage _find_truncated_lens_uniform to calculate
+        # how much to redistribute to each sequence above the target length
+        redistributed_extra_len = cls._find_truncated_lens_uniform(
+            lens=longer_than_average,
+            max_len=extra_len_to_redistribute,
+            # max_length=max_len,
+        )
+
+        # we figure out new lengths by adding the redistributed extra length
+        # to lengths above the target length, and keeping the one below target
+        # length as is.
+        return [
+            target_length + le if ls > target_length else ls
+            for ls, le in zip(lens, redistributed_extra_len)
+        ]
+
+    def transform(self, data: TransformElementType) -> TransformElementType:
+        sequences_to_truncate = [
+            field for name, field in data.items()
+            if name in self.fields_to_truncate
+        ]
+
+        # total_original_len = sum(lens)
+
+
+
+# class TruncateFieldsInPrompt(SingleBaseMapper, GetTokenizerOutputFieldsMixin):
+#     def __init__(
+#         self,
+#         template: str,
+#         tokenizer: PreTrainedTokenizerBase,
+#         max_length: Optional[int] = None,
+#         truncation_strategy: str = "longest",
+#         **tk_kwargs: Any,
+#     ) -> None:
+#         self.tokenizer = tokenizer
+
+#         self.prompt = PromptSegment.from_template(
+#             template=template,
+#             tokenizer=tokenizer
+#         )
+#         self.max_length = (
+#             max_length or tokenizer.model_max_length
+#         ) - sum(len(p) for p in self.prompt)
+
+#         output_fields = self.get_tokenizer_output_fields(**tk_kwargs)
+#         super().__init__(
+#             input_fields=[ps.field_name for ps in self.prompt if ps.field_name],
+#             output_fields=output_fields
+#         )
+
+#     def transform(self, data: TransformElementType) -> TransformElementType:
+#         ...

--- a/src/smashed/mappers/prompting.py
+++ b/src/smashed/mappers/prompting.py
@@ -1,0 +1,85 @@
+from dataclasses import dataclass
+from enum import Enum
+import unicodedata
+from typing import Any, List, Optional, Sequence, Union
+from string import Formatter
+
+from transformers.tokenization_utils_base import PreTrainedTokenizerBase
+
+from ..base import SingleBaseMapper, TransformElementType
+
+
+
+
+
+@dataclass
+class PromptSegment:
+    __slots__ = ("prompt_text", "field_name", "prompt_token_ids",)
+
+    prompt_text: str
+    field_name: Union[str, None]
+    prompt_token_ids: List[int]
+    truncate: bool
+
+    @classmethod
+    def _from_template_single(
+        cls,
+        literal_text: str,
+        field_name: Union[str, None],
+        format_spec: Union[str, None],
+        tokenizer: PreTrainedTokenizerBase,
+    ) -> "PromptSegment":
+        token_ids = tokenizer.encode(literal_text, add_special_tokens=False)
+        return cls(
+            prompt_text=literal_text,
+            field_name=field_name,
+            prompt_token_ids=token_ids,
+            truncate=bool(format_spec),
+        )
+
+    @classmethod
+    def from_template(
+        cls, template: str, tokenizer: PreTrainedTokenizerBase,
+    ) -> List['PromptSegment']:
+        return [
+            cls._from_template_single(
+                literal_text=literal_text,
+                field_name=field_name,
+                tokenizer=tokenizer,
+                format_spec=format_spec,
+            )
+            for literal_text, field_name, format_spec, _
+            in Formatter().parse(template)
+        ]
+
+    def __len__(self):
+        return len(self.prompt_token_ids)
+
+
+class TruncateFieldsInPrompt(SingleBaseMapper, GetTokenizerOutputFieldsMixin):
+    def __init__(
+        self,
+        template: str,
+        tokenizer: PreTrainedTokenizerBase,
+        max_length: Optional[int] = None,
+        truncation_strategy: str = "longest_first",
+        **tk_kwargs: Any,
+    ) -> None:
+        self.tokenizer = tokenizer
+
+        self.prompt = PromptSegment.from_template(
+            template=template,
+            tokenizer=tokenizer
+        )
+        self.max_length = (
+            max_length or tokenizer.model_max_length
+        ) - sum(len(p) for p in self.prompt)
+
+        output_fields = self.get_tokenizer_output_fields(**tk_kwargs)
+        super().__init__(
+            input_fields=[ps.field_name for ps in self.prompt if ps.field_name],
+            output_fields=output_fields
+        )
+
+    def transform(self, data: TransformElementType) -> TransformElementType:
+        ...

--- a/src/smashed/mappers/shape.py
+++ b/src/smashed/mappers/shape.py
@@ -21,6 +21,10 @@ class FlattenMapper(SingleBaseMapper):
 
 
 class UnpackingMapper(BatchedBaseMapper):
+    """Unpacks some or all fields in a dataset sample.
+    Useful when features contain a list of values, but you want to
+    want individual values for each sample."""
+
     _DRP_EXTRA = "drop"
     _RPT_EXTRA = "repeat"
 
@@ -30,10 +34,7 @@ class UnpackingMapper(BatchedBaseMapper):
         fields_to_ignore: Optional[List[str]] = None,
         ignored_behavior: Optional[str] = None,
     ) -> None:
-        """Unpacks some or all fields in a dataset sample.
-        Useful when features contain a list of values, but you want to
-        want individual values for each sample.
-
+        """
         Args:
             fields_to_unpack (Optional[List[str]], optional): List of fields to
                 unpack. When not None, the other fields will be repeated (if
@@ -46,7 +47,7 @@ class UnpackingMapper(BatchedBaseMapper):
                 duplicated, while the others will be unpacked. Only one between
                 `fields_to_unpack` and `fields_to_ignore` can be set. Defaults
                 to None.
-            ignore_behavior (Optional[str]b, optional): How to handle fields
+            ignore_behavior (Optional[str], optional): How to handle fields
                 that are not unpacked. Can be "drop" or "repeat". Defaults to
                 None. Must be set when either `fields_to_unpack` or
                 `fields_to_ignore` is not None.
@@ -101,10 +102,11 @@ class UnpackingMapper(BatchedBaseMapper):
                 all_field_names_to_unpack = [
                     k for k in packed_sample.keys() if self.check_unpack_fn(k)
                 ]
-                if len(all_field_names_to_unpack) == 0:
-                    # raise an error if there's nothing to unpack,
-                    # which might indicate an error in setting up the mapper
-                    raise ValueError("No fields to unpack!")
+
+            if len(all_field_names_to_unpack) == 0:
+                # raise an error if there's nothing to unpack,
+                # which might indicate an error in setting up the mapper
+                raise ValueError("No fields to unpack!")
 
             unpacked_samples_it: Iterable[Dict[str, Any]] = (
                 # this re-attached all the field names to just the values

--- a/src/smashed/mappers/tokenize.py
+++ b/src/smashed/mappers/tokenize.py
@@ -20,25 +20,24 @@ class GetTokenizerOutputFieldsMixin:
     _prefix: Optional[str]
 
     def output_fields_from_tokenizer_kwargs(
-        self,
-        tokenizer_kwargs: Optional[dict] = None
+        self, tokenizer_kwargs: Optional[dict] = None
     ) -> List[str]:
 
         tokenizer_kwargs = tokenizer_kwargs or {}
 
-        output_fields = ['input_ids']
+        output_fields = ["input_ids"]
 
-        if tokenizer_kwargs.get('return_attention_mask', False):
+        if tokenizer_kwargs.get("return_attention_mask", False):
             output_fields.append("attention_mask")
-        if tokenizer_kwargs.get('return_token_type_ids', False):
+        if tokenizer_kwargs.get("return_token_type_ids", False):
             output_fields.append("token_type_ids")
-        if tokenizer_kwargs.get('return_overflowing_tokens', False):
+        if tokenizer_kwargs.get("return_overflowing_tokens", False):
             output_fields.append("overflow_to_sample_mapping")
-        if tokenizer_kwargs.get('return_special_tokens_mask', False):
+        if tokenizer_kwargs.get("return_special_tokens_mask", False):
             output_fields.append("special_tokens_mask")
-        if tokenizer_kwargs.get('return_offsets_mapping', False):
+        if tokenizer_kwargs.get("return_offsets_mapping", False):
             output_fields.append("offset_mapping")
-        if tokenizer_kwargs.get('return_length', False):
+        if tokenizer_kwargs.get("return_length", False):
             output_fields.append("length")
 
         return output_fields
@@ -112,7 +111,7 @@ class TokenizerMapper(SingleBaseMapper, GetTokenizerOutputFieldsMixin):
     def transform(self, data: TransformElementType) -> TransformElementType:
         batch_encoding = self.tokenizer(
             (to_tok_field := data[self.to_tokenize_filed]),
-            **self.tokenize_kwargs
+            **self.tokenize_kwargs,
         )
 
         # token_to_word mappings are unfortunately not natively returned by

--- a/src/smashed/mappers/tokenize.py
+++ b/src/smashed/mappers/tokenize.py
@@ -5,15 +5,47 @@
 
 """
 
+from dataclasses import dataclass
+from enum import Enum
 import unicodedata
-from typing import Any, List, Optional
+from typing import Any, List, Optional, Sequence, Union
+from string import Formatter
 
 from transformers.tokenization_utils_base import PreTrainedTokenizerBase
 
 from ..base import SingleBaseMapper, TransformElementType
 
 
-class TokenizerMapper(SingleBaseMapper):
+
+class GetTokenizerOutputFieldsMixin:
+    tokenizer: PreTrainedTokenizerBase
+
+    def get_tokenizer_output_fields(
+        self,
+        tokenizer_kwargs: Optional[dict] = None
+    ) -> List[str]:
+
+        tokenizer_kwargs = tokenizer_kwargs or {}
+
+        output_fields = ['input_ids']
+
+        if 'return_attention_mask' in tokenizer_kwargs:
+            output_fields.append("attention_mask")
+        if 'return_token_type_ids' in tokenizer_kwargs:
+            output_fields.append("token_type_ids")
+        if 'return_overflowing_tokens' in tokenizer_kwargs:
+            output_fields.append("overflow_to_sample_mapping")
+        if 'return_special_tokens_mask' in tokenizer_kwargs:
+            output_fields.append("special_tokens_mask")
+        if 'return_offsets_mapping' in tokenizer_kwargs:
+            output_fields.append("offset_mapping")
+        if 'return_length' in tokenizer_kwargs:
+            output_fields.append("length")
+
+        return output_fields
+
+
+class TokenizerMapper(SingleBaseMapper, GetTokenizerOutputFieldsMixin):
     def __init__(
         self,
         tokenizer: PreTrainedTokenizerBase,
@@ -41,35 +73,16 @@ class TokenizerMapper(SingleBaseMapper):
             "add_special_tokens": add_special_tokens,
             "max_length": max_length,
             "is_split_into_words": is_split_into_words,
+            "return_attention_mask": return_attention_mask,
+            "return_token_type_ids": return_token_type_ids,
+            "return_overflowing_tokens": return_overflowing_tokens,
+            "return_special_tokens_mask": return_special_tokens_mask,
+            "return_offsets_mapping": return_offsets_mapping,
+            "return_length": return_length,
             **(tk_kwargs or {}),
         }
 
-        output_fields = ["input_ids"]
-
-        # various options for the tokenizer affect which fields are returned
-        tk_kwargs["return_attention_mask"] = return_attention_mask
-        if return_attention_mask:
-            output_fields.append("attention_mask")
-
-        tk_kwargs["return_token_type_ids"] = return_token_type_ids
-        if return_token_type_ids:
-            output_fields.append("token_type_ids")
-
-        tk_kwargs["return_overflowing_tokens"] = return_overflowing_tokens
-        if return_overflowing_tokens:
-            output_fields.append("overflow_to_sample_mapping")
-
-        tk_kwargs["return_special_tokens_mask"] = return_special_tokens_mask
-        if return_special_tokens_mask:
-            output_fields.append("special_tokens_mask")
-
-        tk_kwargs["return_offsets_mapping"] = return_offsets_mapping
-        if return_offsets_mapping:
-            output_fields.append("offset_mapping")
-
-        tk_kwargs["return_length"] = return_length
-        if return_length:
-            output_fields.append("length")
+        output_fields = self.get_tokenizer_output_fields(tk_kwargs)
 
         self.return_word_ids = self.return_words = False
         if "is_split_into_words" in tk_kwargs and return_word_ids:

--- a/src/smashed/mappers/tokenize.py
+++ b/src/smashed/mappers/tokenize.py
@@ -1,5 +1,5 @@
 """
-
+Bunch of tokenization mappers for the smashed library.
 
 @lucas, @kylel
 
@@ -10,6 +10,12 @@ from typing import Any, List, Optional
 from transformers.tokenization_utils_base import PreTrainedTokenizerBase
 
 from ..base import SingleBaseMapper, TransformElementType
+
+__all__ = [
+    "PaddingMapper",
+    "TokenizerMapper",
+    "ValidUnicodeMapper",
+]
 
 
 class GetTokenizerOutputFieldsMixin:
@@ -50,6 +56,8 @@ class GetTokenizerOutputFieldsMixin:
 
 
 class TokenizerMapper(SingleBaseMapper, GetTokenizerOutputFieldsMixin):
+    """Tokenize a field using a tokenizer."""
+
     def __init__(
         self,
         tokenizer: PreTrainedTokenizerBase,
@@ -68,6 +76,40 @@ class TokenizerMapper(SingleBaseMapper, GetTokenizerOutputFieldsMixin):
         return_words: Optional[bool] = False,
         **tokenizer_kwargs: Any,
     ) -> None:
+        """
+        Args:
+            tokenizer (PreTrainedTokenizerBase): A tokenizer from the
+                huggingface/transformers library.
+            input_field (str): The field to tokenize.
+            output_prefix (Optional[str], optional): A prefix to add to all
+                output fields. Defaults to None.
+            add_special_tokens (Optional[bool], optional): Whether or not to
+                add special tokens to the input. Defaults to True.
+            max_length (Optional[int], optional): The maximum length of the
+                input. If not provided, tokenizer.model_max_length will be
+                used. Defaults to None.
+            is_split_into_words (bool, optional): Whether or not the input
+                is already split into words. Defaults to False.
+            return_token_type_ids (bool, optional): Whether or not to return
+                token type ids. Defaults to False.
+            return_attention_mask (bool, optional): Whether or not to return
+                attention masks. Defaults to True.
+            return_overflowing_tokens (bool, optional): Whether or not to
+                return overflowing tokens. Defaults to False.
+            return_special_tokens_mask (bool, optional): Whether or not to
+                return special tokens masks. Defaults to False.
+            return_offsets_mapping (bool, optional): Whether or not to return
+                offsets mappings. Defaults to False.
+            return_length (bool, optional): Whether or not to return the
+                length of the input. Defaults to False.
+            return_word_ids (bool, optional): Whether or not to return the
+                word ids. Defaults to False.
+            return_words (bool, optional): Whether or not to return the
+                words. Defaults to False.
+            tokenizer_kwargs (Any): Additional keyword arguments to pass
+                to the tokenizer; these will override the above arguments.
+        """
+
         self.to_tokenize_filed = input_field
         self.tokenizer = tokenizer
         self._prefix = output_prefix

--- a/src/smashed/recipes/__init__.py
+++ b/src/smashed/recipes/__init__.py
@@ -1,0 +1,3 @@
+from .prompting import PromptingMapperRecipe
+
+__all__ = ["PromptingMapperRecipe"]

--- a/src/smashed/recipes/prompting.py
+++ b/src/smashed/recipes/prompting.py
@@ -119,7 +119,6 @@ class PromptingMapperRecipe(EncodeFieldsMapper):
 
         self.chain(
             RenameFieldsMapper(
-                rename_fields_map=rename_fields_map,
-                remove_rest=True
+                rename_fields_map=rename_fields_map, remove_rest=True
             )
         )

--- a/src/smashed/recipes/prompting.py
+++ b/src/smashed/recipes/prompting.py
@@ -1,0 +1,113 @@
+from typing import Literal, Optional, Sequence, Union
+
+from transformers.tokenization_utils_base import PreTrainedTokenizerBase
+
+from ..mappers.fields import RenameFieldsMapper
+from ..mappers.prompting import (
+    EncodeFieldsMapper,
+    FillEncodedPromptMapper,
+    TruncateNFieldsMapper,
+)
+
+
+class PromptingMapperRecipe(EncodeFieldsMapper):
+    """A recipe of chained mappers for prompting tasks.
+
+    As input, it takes a dictionary of fields that need to be inserted
+    into a prompt. It outputs input_ids, etc.
+    """
+
+    def __init__(
+        self,
+        tokenizer: PreTrainedTokenizerBase,
+        encoding_template: str,
+        decoding_template: Optional[str] = None,
+        fields_to_truncate: Optional[Sequence[str]] = None,
+        decoding_output_name: Union[
+            Literal["labels"], Literal["decoder_input_ids"]
+        ] = "labels",
+        is_split_into_words: bool = False,
+        max_source_length: Optional[int] = None,
+        max_target_length: Optional[int] = None,
+        strategy: Union[Literal["longest"], Literal["uniform"]] = "longest",
+        return_attention_mask: bool = True,
+        return_token_type_ids: bool = False,
+    ):
+        fields_to_truncate = fields_to_truncate or []
+
+        source_prompt_mapper = FillEncodedPromptMapper(
+            template=encoding_template,
+            tokenizer=tokenizer,
+            output_prefix=None,
+            return_attention_mask=return_attention_mask,
+            return_token_type_ids=return_token_type_ids,
+        )
+        fields_to_encode = source_prompt_mapper.input_fields
+
+        if decoding_template is not None:
+            target_prompt_mapper = FillEncodedPromptMapper(
+                template=decoding_template,
+                tokenizer=tokenizer,
+                return_attention_mask=False,
+                # we will change this later
+                output_prefix="decoder_",
+            )
+            fields_to_encode += target_prompt_mapper.input_fields
+        else:
+            target_prompt_mapper = None
+
+        super().__init__(
+            fields_to_encode=fields_to_encode,
+            tokenizer=tokenizer,
+            is_split_into_words=is_split_into_words,
+        )
+
+        source_fields_to_truncate, source_fields_to_preserve = [], []
+        for field_name in source_prompt_mapper.input_fields:
+            if field_name in fields_to_truncate:
+                source_fields_to_truncate.append(field_name)
+            else:
+                source_fields_to_preserve.append(field_name)
+
+        source_truncation_mapper = TruncateNFieldsMapper(
+            fields_to_truncate=source_fields_to_truncate,
+            fields_to_preserve=source_fields_to_preserve,
+            max_length=max_source_length,
+            strategy=strategy,
+            tokenizer=tokenizer,
+            length_penalty=sum(len(ps) for ps in source_prompt_mapper.prompt),
+        )
+        self.chain(source_truncation_mapper)
+
+        if target_prompt_mapper:
+            target_fields_to_truncate, target_fields_to_preserve = [], []
+            for field_name in target_prompt_mapper.input_fields:
+                if field_name in fields_to_truncate:
+                    target_fields_to_truncate.append(field_name)
+                else:
+                    target_fields_to_preserve.append(field_name)
+            target_truncation_mapper = TruncateNFieldsMapper(
+                fields_to_truncate=target_fields_to_truncate,
+                fields_to_preserve=target_fields_to_preserve,
+                max_length=max_target_length or max_source_length,
+                strategy=strategy,
+                tokenizer=tokenizer,
+                length_penalty=sum(
+                    len(ps) for ps in target_prompt_mapper.prompt
+                ),
+            )
+            self.chain(target_truncation_mapper)
+
+        self.chain(source_prompt_mapper)
+
+        rename_fields_map = {k: k for k in source_prompt_mapper.output_fields}
+
+        if target_prompt_mapper:
+            self.chain(target_prompt_mapper)
+
+            if decoding_output_name == "labels":
+                rename_fields_map["decoder_input_ids"] = "labels"
+            else:
+                rename_fields_map["decoder_input_ids"] = "decoder_input_ids"
+
+        self.chain(RenameFieldsMapper(rename_fields_map=rename_fields_map))

--- a/src/smashed/utils.py
+++ b/src/smashed/utils.py
@@ -2,13 +2,12 @@ import importlib.metadata
 import os
 import warnings
 from pathlib import Path
-from typing import Optional, Type, TypeVar, Union, TYPE_CHECKING
+from typing import TYPE_CHECKING, Optional, Type, TypeVar, Union
 
 import platformdirs
 
-
 if TYPE_CHECKING:
-    from .base import (SingleBaseMapper, BatchedBaseMapper)
+    from .base import BatchedBaseMapper, SingleBaseMapper
 
 
 M = TypeVar("M", "SingleBaseMapper", "BatchedBaseMapper")

--- a/src/smashed/utils.py
+++ b/src/smashed/utils.py
@@ -2,9 +2,16 @@ import importlib.metadata
 import os
 import warnings
 from pathlib import Path
-from typing import Optional, Type, Union
+from typing import Optional, Type, TypeVar, Union, TYPE_CHECKING
 
 import platformdirs
+
+
+if TYPE_CHECKING:
+    from .base import (SingleBaseMapper, BatchedBaseMapper)
+
+
+M = TypeVar("M", "SingleBaseMapper", "BatchedBaseMapper")
 
 
 def get_version() -> str:
@@ -83,3 +90,13 @@ def int_from_bytes(b: bytes) -> int:
 def bytes_from_int(i: int) -> bytes:
     """Convert an integer to a byte string."""
     return i.to_bytes((i.bit_length() + 7) // 8, byteorder="big")
+
+
+def make_pipeline(
+    first_mapper: M,
+    *rest_mappers: Union["SingleBaseMapper", "BatchedBaseMapper"]
+) -> M:
+    """Make a pipeline of mappers."""
+    for mapper in rest_mappers:
+        first_mapper = first_mapper.chain(mapper)
+    return first_mapper

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -9,6 +9,7 @@ import copy
 import unittest
 
 from smashed.base.mappers import SingleBaseMapper
+from smashed.utils import make_pipeline
 
 
 class MockMapper(SingleBaseMapper):
@@ -83,6 +84,14 @@ class TestPipeline(unittest.TestCase):
     def test_run_pipeline(self):
         """Test a full pipeline"""
         pipeline = MockMapper(1) >> MockMapper(2) >> MockMapper(3)
+
+        dataset = [{"stage": [0]}]
+        dataset = pipeline.map(dataset)
+
+        self.assertEqual(dataset[0]["stage"], [0, 1, 2, 3])
+
+    def test_make_pipeline_function(self):
+        pipeline = make_pipeline(MockMapper(1), MockMapper(2), MockMapper(3))
 
         dataset = [{"stage": [0]}]
         dataset = pipeline.map(dataset)

--- a/tests/test_prompting.py
+++ b/tests/test_prompting.py
@@ -1,0 +1,47 @@
+import unittest
+
+from smashed.mappers.prompting import TruncateFieldsMapper
+
+
+class TestTruncate(unittest.TestCase):
+    def test_lengths_algo_uniform(self):
+        lens = [10, 8, 6, 4, 2]
+        max_len = 20
+        truncated = [6, 5, 4, 2, 1]
+        self.assertEqual(
+            TruncateFieldsMapper._find_truncated_lens_uniform(
+                lens=lens, max_len=max_len
+            ),
+            truncated,
+        )
+
+        lens = [50, 40, 1, 1, 1]
+        max_len = 20
+        truncated = [10, 8, 0, 0, 0]
+        self.assertEqual(
+            TruncateFieldsMapper._find_truncated_lens_uniform(
+                lens=lens, max_len=max_len
+            ),
+            truncated,
+        )
+
+    def test_lengths_algo_longest(self):
+        lens = [10, 8, 6, 4, 2]
+        max_len = 20
+        truncated = [5, 4, 4, 4, 2]
+        self.assertEqual(
+            TruncateFieldsMapper._find_truncated_lens_longest(
+                lens=lens, max_len=max_len
+            ),
+            truncated,
+        )
+
+        lens = [50, 40, 1, 1, 1]
+        max_len = 20
+        truncated = [9, 7, 1, 1, 1]
+        self.assertEqual(
+            TruncateFieldsMapper._find_truncated_lens_longest(
+                lens=lens, max_len=max_len
+            ),
+            truncated,
+        )

--- a/tests/test_prompting.py
+++ b/tests/test_prompting.py
@@ -1,6 +1,13 @@
+from tempfile import NamedTemporaryFile
 import unittest
 
-from smashed.mappers.prompting import TruncateFieldsMapper
+from smashed.mappers.prompting import (
+    TruncateFieldsMapper,
+    EncodeFieldsMapper,
+    FillEncodedPromptMapper,
+)
+
+from transformers.models.bert import BertTokenizer
 
 
 class TestTruncate(unittest.TestCase):
@@ -44,4 +51,102 @@ class TestTruncate(unittest.TestCase):
                 lens=lens, max_len=max_len
             ),
             truncated,
+        )
+
+    def _make_tokenizer(self) -> BertTokenizer:
+        with NamedTemporaryFile(mode="r+") as f:
+            vocab = [
+                "[PAD]", "[UNK]", "[CLS]", "[SEP]", "hello", "world",
+                "this", "is", "a", "test", "hi", "there", "many", "##i",
+                "with", "the", "of"
+            ]
+            f.write('\n'.join(vocab))
+            f.flush()
+            tokenizer = BertTokenizer(f.name, do_lower_case=True)
+
+        tokenizer.model_max_length = 32
+        return tokenizer
+
+    def test_encode(self):
+        tokenizer = self._make_tokenizer()
+
+        mapper = EncodeFieldsMapper(
+            fields_to_encode=["a", "b", "c"], tokenizer=tokenizer,
+        ) >> TruncateFieldsMapper(
+            fields_to_truncate=["a", "b"],
+            fields_to_preserve=["c"],
+            max_length=16,
+            strategy="longest",
+        )
+        data = [{
+            "a": "many " * 30 + " hello world",
+            "b": "hi" + "i" * 10 + " there",
+            "c": "this is a test",
+        }]
+
+        predicted = mapper.map(data)
+        reference = [{
+            "a": [12, 12, 12, 12, 12, 12],
+            "b": [10, 13, 13, 13, 13, 13],
+            'c': [6, 7, 8, 9]
+        }]
+        self.assertEqual(predicted, reference)
+
+        mapper.pipeline.strategy = "uniform"    # pyright: ignore
+        predicted = mapper.map(data)
+        reference = [{
+            "a": [12, 12, 12, 12, 12, 12, 12, 12],
+            "b": [10, 13, 13],
+            'c': [6, 7, 8, 9]
+        }]
+        self.assertEqual(predicted, reference)
+
+    def test_fill(self):
+        tokenizer = self._make_tokenizer()
+        mapper = EncodeFieldsMapper(
+            fields_to_encode=["a", "b", "c"], tokenizer=tokenizer,
+        ) >> TruncateFieldsMapper(
+            fields_to_truncate=["a", "b"],
+            fields_to_preserve=["c"],
+            max_length=16,
+            strategy="uniform",
+        ) >> FillEncodedPromptMapper(
+            template="{a} is a {b} with the help of {c}.",
+            tokenizer=tokenizer,
+        )
+
+        data = [{
+            "a": "many " * 30 + " hello world",
+            "b": "hi" + "i" * 10 + " there",
+            "c": "this is a test",
+        }]
+
+        output = mapper.map(data, remove_columns=True)
+
+        reference = [{
+            'input_ids' : (
+                # {a}
+                [12, 12, 12, 12, 12, 12, 12, 12]
+                # is a
+                + [7, 8]
+                # {b}
+                + [10, 13, 13]
+                # with the help of
+                + [14, 15, 1, 16]
+                # {c}
+                + [6, 7, 8, 9]
+                # .
+                + [1]
+            ),
+            'attention_mask': [1] * 22
+        }]
+        print(output)
+        # breakpoint()
+        self.assertEqual(len(output), len(reference))
+        self.assertEqual(output[0].keys(), reference[0].keys())
+        self.assertEqual(
+            output[0]['input_ids'], reference[0]['input_ids']
+        )
+        self.assertEqual(
+            output[0]['attention_mask'], reference[0]['attention_mask']
         )


### PR DESCRIPTION
This PR adds the following:

- Quite a few prompting-related mappers in `smashed.mappers.prompting`, plus a new recipe for all your prompting needs in `PromptingMapperRecipe`
- In general, the concept of *recipes*, which a chain of mappers nicely strung together 
- The return of a easy function to make pipelines at `smashed.pipeline(mapper_1, mapper_2, ..., mapper_n)`
- Documentation updates
- Cleaned up way to force dropping columns via an `always_remove_columns` `@classproperty`.
- A new mapper `RenameFieldsMapper` to rename fields.