### PR TITLE
Pickle/Dill test + requirements.txt file

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "smashed"
-version = "0.4.0"
+version = "0.4.1"
 description = "Sequential MAppers for Sequences of HEterogeneous Dictionaries is a set of Python interfaces designed to apply transformations to samples in datasets, which are often implemented as sequences of dictionaries."
 authors = [
     {name = "Allen Institute for Artificial Intelligence", email = "contact@allenai.org" },
@@ -9,14 +9,11 @@ authors = [
 license = {text = "Apache-2.0"}
 readme = "README.md"
 requires-python = ">=3.8"
-dependencies = [
-    "torch>=1.9",
-    "transformers>=4.5",
-    "necessary>=0.2.3",
-    "trouting>=0.2.2",
-    "ftfy>=6.1.1",
-    "platformdirs>=2.5.0",
-]
+dynamic = ["dependencies"]
+
+[tool.setuptools.dynamic]
+dependencies = {file = ["requirements.txt"]}
+
 
 [project.urls]
 "Homepage" = "https://github.com/allenai/smashed"
@@ -57,7 +54,8 @@ remote = [
     "smart-open>=5.2.1"
 ]
 datasets = [
-  "datasets>=2.4.0"
+  "datasets>=2.4.0",
+  "dill>=0.3.0"
 ]
 torchdata = [
   "torch>=1.12.1",

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,6 @@
+torch>=1.9
+transformers>=4.5
+necessary>=0.2.3
+trouting>=0.2.2
+ftfy>=6.1.1
+platformdirs>=2.5.0

--- a/tests/test_hf_pickling.py
+++ b/tests/test_hf_pickling.py
@@ -7,6 +7,7 @@ from smashed.base import SingleBaseMapper
 
 with necessary("datasets"):
     from datasets.fingerprint import Hasher
+    import dill
 
 
 class MockMapper(SingleBaseMapper):
@@ -43,9 +44,21 @@ class TestPickling(unittest.TestCase):
         hasher.update(m.transform)
         hasher.hexdigest()
 
+    def test_dill(self):
+        """Test if caching works"""
 
-if __name__ == "__main__":
-    import springs as sp
+        # this should not fail
+        m = MockMapper() >> MockMapper()
+        m2 = dill.loads(dill.dumps(m))
+        self.assertEqual(m, m2)
 
-    sp.configure_logging()
-    TestPickling().test_pickle()
+        # the dilled pipeline should yield same results
+        dt = [{"a": 1, "b": 2}]
+        out1 = m.map(dt)
+        out2 = m2.map(dt)
+        self.assertEqual(out1, out2)
+
+        # this should not fail if class is dillable
+        hasher = Hasher()
+        hasher.update(m.transform)
+        hasher.hexdigest()

--- a/tests/test_hf_pickling.py
+++ b/tests/test_hf_pickling.py
@@ -5,7 +5,7 @@ from necessary import necessary
 
 from smashed.base import SingleBaseMapper
 
-with necessary("datasets"):
+with necessary(("datasets", "dill")):
     import dill
     from datasets.fingerprint import Hasher
 

--- a/tests/test_hf_pickling.py
+++ b/tests/test_hf_pickling.py
@@ -6,8 +6,8 @@ from necessary import necessary
 from smashed.base import SingleBaseMapper
 
 with necessary("datasets"):
-    from datasets.fingerprint import Hasher
     import dill
+    from datasets.fingerprint import Hasher
 
 
 class MockMapper(SingleBaseMapper):


### PR DESCRIPTION
- added test to make sure mappers are dill serializable
- pulled out requirements txt file since GitHub can't otherwise parse dependency tree