### PR TITLE
fixes to make mappers with set attributes Hashable

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "smashed"
-version = "0.6.0"
+version = "0.6.1"
 description = "Sequential MAppers for Sequences of HEterogeneous Dictionaries is a set of Python interfaces designed to apply transformations to samples in datasets, which are often implemented as sequences of dictionaries."
 authors = [
     {name = "Allen Institute for Artificial Intelligence", email = "contact@allenai.org" },
@@ -43,7 +43,7 @@ requires = [
 [project.optional-dependencies]
 dev = [
     "springs>=1.4.2",
-    "black>=22.6.0",
+    "black[jupyter]>=22.6.0",
     "isort>=5.10.1",
     "mypy>=0.971",
     "pytest>=5.2",

--- a/src/smashed/base/mappers.py
+++ b/src/smashed/base/mappers.py
@@ -3,7 +3,7 @@ import hashlib
 import inspect
 import pickle
 from itertools import chain
-from typing import Iterable, NamedTuple, Optional, TypeVar, Union
+from typing import Iterable, NamedTuple, Optional, Tuple, TypeVar, Union
 
 from ..utils import bytes_from_int, int_from_bytes
 from .abstract import (
@@ -19,6 +19,9 @@ P = TypeVar("P", bound="PipelineFingerprintMixIn")
 
 class PipelineFingerprintMixIn(AbstractBaseMapper):
 
+    input_fields: Tuple[str, ...]
+    output_fields: Tuple[str, ...]
+    fingerprint: str
     pipeline: Union["PipelineFingerprintMixIn", None]
 
     def __init__(
@@ -29,16 +32,17 @@ class PipelineFingerprintMixIn(AbstractBaseMapper):
         """Create a new Mapper.
 
         Args:
-            input_fields (Optional[List[str]], optional): The fields expected
-                by this mapper. If None is provided, the mapper will not
-                check for the presence of any input fields. Defaults to None.
-            output_fields (Optional[List[str]], optional): The fields produced
-                by this mapper after transformation. If None is provided, the
-                mapper will not validate the output of transform. Defaults to
-                None.
+            input_fields (Optional[Iterable[str]], optional): The fields
+                expected by this mapper. If None is provided, the mapper will
+                not check for the presence of any input fields.
+                Defaults to None.
+            output_fields (Optional[Iterable[str]], optional): The fields
+                produced by this mapper after transformation. If None is
+                provided, the mapper will not validate the output of transform.
+                Defaults to None.
         """
-        self.input_fields = tuple(input_fields or [])
-        self.output_fields = tuple(output_fields or [])
+        self.input_fields = tuple(sorted(set(input_fields or [])))
+        self.output_fields = tuple(sorted(set(output_fields or [])))
         self.fingerprint = self._get_mapper_fingerprint()
         self.pipeline = None
 

--- a/src/smashed/mappers/multiseq.py
+++ b/src/smashed/mappers/multiseq.py
@@ -2,6 +2,7 @@ import itertools
 import random
 from typing import (
     Any,
+    Dict,
     Iterable,
     List,
     Literal,
@@ -477,12 +478,21 @@ class SingleValueToSequenceMapper(SingleBaseMapper):
 
 
 class SequencesConcatenateMapper(SingleBaseMapper):
+
+    concat_fields: Union[Dict[str, None], None]
+
     def __init__(self, concat_fields: Optional[List[str]] = None):
         super().__init__(
             input_fields=concat_fields, output_fields=concat_fields
         )
         self.concat_fields = (
-            set(concat_fields) if concat_fields is not None else None
+            # @soldni: using `dict.fromkeys` in place of `frozenset` to avoid
+            # issues with hashability: sets are not guaranteed to have the
+            # same hash, which causes issues when trying to cache through
+            # huggingface datasets.
+            dict.fromkeys(concat_fields)
+            if concat_fields is not None
+            else None
         )
 
     def _to_concat(self, field_name: str) -> bool:

--- a/src/smashed/mappers/prompting.py
+++ b/src/smashed/mappers/prompting.py
@@ -138,8 +138,8 @@ class TruncateNFieldsMapper(SingleBaseMapper):
             )
 
         self.tokenizer = tokenizer
-        self.fields_to_truncate = sorted(set(fields_to_truncate))
-        self.fields_to_preserve = sorted(set(fields_to_preserve or []))
+        self.fields_to_truncate = tuple(sorted(set(fields_to_truncate)))
+        self.fields_to_preserve = tuple(sorted(set(fields_to_preserve or [])))
         self.max_length = max_length - length_penalty
         self.strategy = strategy
         super().__init__(

--- a/src/smashed/mappers/prompting.py
+++ b/src/smashed/mappers/prompting.py
@@ -26,6 +26,10 @@ INT_MAX_LENGTH = sys.maxsize
 class EncodeFieldsMapper(SingleBaseMapper):
     """Simply encodes the fields in the input data using the tokenizer."""
 
+    tokenizer: PreTrainedTokenizerBase
+    is_split_into_words: bool
+    fields_to_encode: Dict[str, None]
+
     def __init__(
         self,
         fields_to_encode: Sequence[str],
@@ -43,7 +47,12 @@ class EncodeFieldsMapper(SingleBaseMapper):
 
         self.tokenizer = tokenizer
         self.is_split_into_words = is_split_into_words
-        self.fields_to_encode = set(fields_to_encode)
+        # @soldni: using `dict.fromkeys` in place of `frozenset` to avoid
+        # issues with hashability: sets are not guaranteed to have the
+        # same hash, which causes issues when trying to cache through
+        # huggingface datasets.
+        self.fields_to_encode = dict.fromkeys(fields_to_encode)
+
         super().__init__(
             input_fields=fields_to_encode,
             output_fields=fields_to_encode,

--- a/src/smashed/mappers/text.py
+++ b/src/smashed/mappers/text.py
@@ -1,5 +1,5 @@
 import inspect
-from typing import Any, List, Union
+from typing import Any, Dict, List, Union
 
 from ftfy import TextFixerConfig, fix_text
 
@@ -8,6 +8,8 @@ from ..base import SingleBaseMapper, TransformElementType
 
 class FtfyMapper(SingleBaseMapper):
     """Uses ftfy to fix text encoding and general weirdness issues."""
+
+    fields_to_fix: Dict[str, None]
 
     def __init__(
         self,
@@ -27,7 +29,11 @@ class FtfyMapper(SingleBaseMapper):
         if isinstance(input_fields, str):
             input_fields = [input_fields]
 
-        self.fields_to_fix = set(input_fields)
+        # @soldni: using `dict.fromkeys` in place of `frozenset` to avoid
+        # issues with hashability: sets are not guaranteed to have the
+        # same hash, which causes issues when trying to cache through
+        # huggingface datasets.
+        self.fields_to_fix = dict.fromkeys(input_fields)
 
         # check if options for ftfy are valid
         valid_ftfy_args = set(inspect.getfullargspec(TextFixerConfig).args)

--- a/tests/test_hf_pickling.py
+++ b/tests/test_hf_pickling.py
@@ -3,7 +3,11 @@ import unittest
 
 from necessary import necessary
 
-from smashed.mappers import TokenizerMapper, UnpackingMapper
+from smashed.mappers import (
+    TokenizerMapper,
+    TruncateNFieldsMapper,
+    UnpackingMapper,
+)
 from smashed.mappers.debug import MockMapper
 
 with necessary(("datasets", "dill")):
@@ -82,6 +86,18 @@ class TestPickling(unittest.TestCase):
             tokenizer=AutoTokenizer.from_pretrained("bert-base-uncased"),
             input_field="a",
         )
+
+        hashes = set()
+        for _ in range(100):
+            processed_dataset = mp.map(dataset)
+            hashes.add(processed_dataset._fingerprint)
+
+        self.assertEqual(len(hashes), 1)
+
+    def test_truncate_fingerprint(self):
+        mp = TruncateNFieldsMapper(fields_to_truncate=["a", "b"], max_length=2)
+
+        dataset = Dataset.from_dict({"a": [[1, 2, 3]], "b": [[4, 5, 6]]})
 
         hashes = set()
         for _ in range(100):

--- a/tests/test_hf_pickling.py
+++ b/tests/test_hf_pickling.py
@@ -3,11 +3,16 @@ import unittest
 
 from necessary import necessary
 
+from smashed.mappers import TokenizerMapper, UnpackingMapper
 from smashed.mappers.debug import MockMapper
 
 with necessary(("datasets", "dill")):
     import dill
+    from datasets.arrow_dataset import Dataset
     from datasets.fingerprint import Hasher
+
+with necessary("transformers"):
+    from transformers import AutoTokenizer
 
 
 class TestPickling(unittest.TestCase):
@@ -48,3 +53,39 @@ class TestPickling(unittest.TestCase):
         hasher = Hasher()
         hasher.update(m.transform)
         hasher.hexdigest()
+
+    def test_unpacking_fingerprint(self):
+        """Test if fingerprinting works"""
+        mp = (
+            UnpackingMapper(
+                fields_to_unpack=["a", "b"], ignored_behavior="drop"
+            )
+            >> MockMapper(1)
+            >> MockMapper(1)
+        )
+
+        dataset = Dataset.from_dict({"a": [[1, 2, 3]], "b": [[4, 5, 6]]})
+
+        hashes = set()
+        for _ in range(100):
+            processed_dataset = mp.map(dataset)
+            hashes.add(processed_dataset._fingerprint)
+
+        self.assertEqual(len(hashes), 1)
+
+    def test_tokenizer_fingerprint(self):
+        dataset = Dataset.from_dict(
+            {"a": ["hello world", "my name is john doe"]}
+        )
+
+        mp = TokenizerMapper(
+            tokenizer=AutoTokenizer.from_pretrained("bert-base-uncased"),
+            input_field="a",
+        )
+
+        hashes = set()
+        for _ in range(100):
+            processed_dataset = mp.map(dataset)
+            hashes.add(processed_dataset._fingerprint)
+
+        self.assertEqual(len(hashes), 1)

--- a/tests/test_prompting.py
+++ b/tests/test_prompting.py
@@ -142,8 +142,6 @@ class TestTruncate(unittest.TestCase):
             )
         )
 
-        print(mapper)
-
         data = [
             {
                 "a": "many " * 30 + " hello world",


### PR DESCRIPTION
This fix ensures that mappers that used to have sets as attribute have now consistent hashes.